### PR TITLE
Facebook iOS SDK 4.1 split up the pods

### DIFF
--- a/CognitoSync-Sample/Objective-C/Podfile
+++ b/CognitoSync-Sample/Objective-C/Podfile
@@ -1,5 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-pod 'AWSCognito', '~> 2.1.0'
-pod 'Facebook-iOS-SDK', '~> 3.0'
+pod 'AWSCognito'
+pod 'FBSDKCoreKit'
+pod 'FBSDKLoginKit'
 #pod 'google-plus-ios-sdk'

--- a/CognitoSync-Sample/Objective-C/README.md
+++ b/CognitoSync-Sample/Objective-C/README.md
@@ -18,7 +18,8 @@ This sample demonstrates how to create unique identities for users of your app u
 1. To install the AWS Mobile SDK for iOS, simply add the following line to your **Podfile**:
 
 		pod 'AWSCognito'
-		pod 'Facebook-iOS-SDK' 
+		pod 'FBSDKCoreKit'
+		pod 'FBSDKLoginKit'
 
 	Then run the following command:
 	


### PR DESCRIPTION
Facebook splitted up their SDK cocoa pods . To have a working Facebook provider, one needs to change the specification.