### PR TITLE
Update AmazonClientManager.swift

### DIFF
--- a/CognitoSync-Sample/Swift/CognitoSyncDemo/AmazonClientManager.swift
+++ b/CognitoSync-Sample/Swift/CognitoSyncDemo/AmazonClientManager.swift
@@ -253,6 +253,7 @@ class AmazonClientManager : NSObject, GPPSignInDelegate, AIAuthenticationDelegat
         }
         self.fbLoginManager?.logOut()
         self.keyChain[FB_PROVIDER] = nil
+        self.fbLoginManager = nil
     }
     
     func completeFBLogin() {


### PR DESCRIPTION
Fixes the problem that provoques that when you log in via facebook, then you logout, and the you login again, it won't show the Facebook window.