### PR TITLE
Fix source directive in podfile (S3TransferManager-Sample Swift)

### DIFF
--- a/S3TransferManager-Sample/Swift/Podfile
+++ b/S3TransferManager-Sample/Swift/Podfile
@@ -1,4 +1,4 @@
-source 'ssh://git.amazon.com:2222/pkg/AWSCocoaPodsSpecs'
+source 'https://github.com/CocoaPods/Specs.git'
 
 platform :ios, '8.0'
 use_frameworks!


### PR DESCRIPTION
The specs repo at ssh://git.amazon.com:2222/pkg/AWSCocoaPodsSpecs is not publicly accessible.

This appears to be the only Podfile that was affected.