### PR TITLE
Moved the region into Constants.m

### DIFF
--- a/CognitoYourUserPools-Sample/Objective-C/CognitoYourUserPoolsSample/Constants.h
+++ b/CognitoYourUserPools-Sample/Objective-C/CognitoYourUserPoolsSample/Constants.h
@@ -17,7 +17,9 @@
 
 
 #import <Foundation/Foundation.h>
+#import "AWSServiceEnum.h"
 
+FOUNDATION_EXPORT AWSRegionType const CognitoIdentityRegion;
 FOUNDATION_EXPORT NSString *const CognitoIdentityUserPoolId;
 FOUNDATION_EXPORT NSString *const CognitoIdentityUserPoolAppClientId;
 FOUNDATION_EXPORT NSString *const CognitoIdentityUserPoolAppClientSecret;

--- a/CognitoYourUserPools-Sample/Objective-C/CognitoYourUserPoolsSample/Constants.m
+++ b/CognitoYourUserPools-Sample/Objective-C/CognitoYourUserPoolsSample/Constants.m
@@ -16,7 +16,9 @@
 //
 
 #import "Constants.h"
+#import "AWSServiceEnum.h"
 
+AWSRegionType const CognitoIdentityRegion = AWSRegionUSEast1;
 NSString *const CognitoIdentityUserPoolId = @"YOUR_USER_POOL_ID";
 NSString *const CognitoIdentityUserPoolAppClientId = @"YOUR_APP_CLIENT_ID";
 NSString *const CognitoIdentityUserPoolAppClientSecret = @"YOUR_APP_CLIENT_SECRET";


### PR DESCRIPTION
As a developer who uses eu-west-1 it wasn't obvious why I was receiving "User pool client xxx does not exist" messages when running the sample.  As someone who is completely new to AWS Cognito it had me stumped, and Google/SO held no answers for me.  Therefore, by moving the region into Constants.m it makes it more obvious that you would need to change this value to get the sample working.