### PR TITLE
Update README.MD (fixed headings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,90 @@
-#The AWS Mobile SDK for iOS Samples
+# The AWS Mobile SDK for iOS Samples
 
 This repository contains sample apps that demonstrate various aspects of the AWS Mobile SDK for iOS. Please refer to **README.md** in each sample directory for more specific instructions.
 
-###Cognito Your User Pools Sample  ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoYourUserPools-Sample/Swift), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoYourUserPools-Sample/Objective-C/))
+### Cognito Your User Pools Sample  ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoYourUserPools-Sample/Swift), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoYourUserPools-Sample/Objective-C/))
 
 This sample demonstrates how sign up and sign in a user to display an authenticated portion of your app.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon Cognito Your User Pools](http://aws.amazon.com/cognito/)
 
-###Cognito Sync Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoSync-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoSync-Sample/Objective-C/))
+### Cognito Sync Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoSync-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/CognitoSync-Sample/Objective-C/))
 
 This sample demonstrates how to securely manage and sync your mobile app data and create unique identities via login providers including Facebook, Google, and Login with Amazon.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon Cognito Sync](http://aws.amazon.com/cognito/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###DynamoDB Object Mapper Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/DynamoDBObjectMapper-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/DynamoDBObjectMapper-Sample/Objective-C/))
+### DynamoDB Object Mapper Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/DynamoDBObjectMapper-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/DynamoDBObjectMapper-Sample/Objective-C/))
 
 This sample demonstrates how to insert / update / delete / query items using DynamoDB Object Mapper.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon DynamoDB](http://aws.amazon.com/dynamodb/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###S3 Transfer Utility Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/S3TransferUtility-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/S3TransferUtility-Sample/Objective-C/))
+### S3 Transfer Utility Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/S3TransferUtility-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/S3TransferUtility-Sample/Objective-C/))
 
 This sample demonstrates how to use the Amazon S3 PreSigned URL Builder to download / upload files in background.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon S3](http://aws.amazon.com/s3/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
 
-###SNS Mobile Push and Mobile Analytics Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/SNS-MobileAnalytics-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/SNS-MobileAnalytics-Sample/Objective-C/))
+### SNS Mobile Push and Mobile Analytics Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/SNS-MobileAnalytics-Sample/Swift/), [Objective-C](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/SNS-MobileAnalytics-Sample/Objective-C/))
 
 This sample demonstrates how to set up Amazon SNS Mobile Push and record events using Amazon Mobile Analytics.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon SNS Mobile Push](http://aws.amazon.com/sns/)
 * [Amazon Mobile Analytics](http://aws.amazon.com/mobileanalytics/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###IoT Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/IoT-Sample/Swift/))
+### IoT Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/IoT-Sample/Swift/))
 
 This sample demonstrates how to publish and subscribe to data using AWS IoT.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon AWS IoT](http://aws.amazon.com/iot/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###IoT Temperature Control Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/IoTTemperatureControl-Sample/Swift/))
+### IoT Temperature Control Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/IoTTemperatureControl-Sample/Swift/))
 
 This sample demonstrates accessing device shadows using Cognito authentication; it works in conjunction with the Temperature Control Example Program in the [AWS IoT JavaScript SDK for Embedded Devices](https://github.com/aws/aws-iot-device-sdk-js).
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon AWS IoT](http://aws.amazon.com/iot/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###Amazon Lex Sample ([ObjC](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/ObjC/), [Swift2.3](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/swift-2.3/), [Swift3](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/swift-3/))
+### Amazon Lex Sample ([ObjC](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/ObjC/), [Swift2.3](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/swift-2.3/), [Swift3](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Lex-Sample/swift-3/))
 
 This sample demonstrates how to use text to text chat and voice to voice chat using Amazon Lex SDK.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon Lex](http://aws.amazon.com/lex/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###Amazon Polly Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Polly-Sample/Swift/))
+### Amazon Polly Sample ([Swift](https://github.com/awslabs/aws-sdk-ios-samples/tree/master/Polly-Sample/Swift/))
 
 This sample demonstrates how to get the list of voices and synthesize speech using Amazon Polly SDK.
 
-####AWS Services Demonstrated:
+#### AWS Services Demonstrated:
 
 * [Amazon Polly](http://aws.amazon.com/polly/)
 * [Amazon Cognito Identity](http://aws.amazon.com/cognito/)
 
-###Sample Apps for Version 1 SDK
+### Sample Apps for Version 1 SDK
 
 Version 1 of the AWS Mobile SDK for iOS is deprecated as of September 29, 2014. If you are building new apps, we recommend you use Version 2.
 


### PR DESCRIPTION
The headings do not render. Headings now require a space after the hashtag (#) in order to render properly.