### PR TITLE
XCode 9 compile error w/ AWSCore Version 2.5.10

### DIFF
--- a/CognitoYourUserPools-Sample/Swift/Podfile
+++ b/CognitoYourUserPools-Sample/Swift/Podfile
@@ -1,9 +1,9 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '8.0'
+platform :ios, '10.0'
 use_frameworks!
 
 target 'CognitoYourUserPoolsSample' do
-    pod 'AWSCore', '~> 2.5.0'
-    pod 'AWSCognitoIdentityProvider', '~> 2.5.0'
+    pod 'AWSCore', '~> 2.6.0'
+    pod 'AWSCognitoIdentityProvider', '~> 2.6.0'
 end


### PR DESCRIPTION
I'm getting the compilation issue mentioned on https://github.com/aws/aws-sdk-ios/issues/721 with version 2.5.10. Setting min version to 2.6.0 solves the problem.