### PR TITLE
[IoT] Update README to attach adequate policies

### DIFF
--- a/IoT-Sample/Swift/README.md
+++ b/IoT-Sample/Swift/README.md
@@ -37,7 +37,7 @@ This sample demonstrates use of the AWS IoT APIs to securely publish to and subs
               "Action": [
                 "iot:AttachPrincipalPolicy",
                 "iot:CreateKeysAndCertificate",
-		"iot:CreateCertificateFromCsr"
+                "iot:CreateCertificateFromCsr"
               ],
               "Resource": [
                 "*"

--- a/IoT-Sample/Swift/README.md
+++ b/IoT-Sample/Swift/README.md
@@ -36,7 +36,8 @@ This sample demonstrates use of the AWS IoT APIs to securely publish to and subs
               "Effect": "Allow",
               "Action": [
                 "iot:AttachPrincipalPolicy",
-                "iot:CreateKeysAndCertificate"
+                "iot:CreateKeysAndCertificate",
+		"iot:CreateCertificateFromCsr"
               ],
               "Resource": [
                 "*"


### PR DESCRIPTION
The steps to attach policies is missing "iot:CreateCertificateFromCsr" but the sample code uses the API which needs the policy.