### PR TITLE
base 64 decode the response if response includes special characters

### DIFF
--- a/Lex-Sample/Swift/LexSwift.xcodeproj/project.pbxproj
+++ b/Lex-Sample/Swift/LexSwift.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		17DD067D1DD3C34A00BD639D /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DD067C1DD3C34A00BD639D /* ChatViewController.swift */; };
 		17DD068E1DD3EE9D00BD639D /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DD068D1DD3EE9D00BD639D /* TableViewController.swift */; };
 		17DD06921DD3F18100BD639D /* VoiceChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DD06911DD3F18100BD639D /* VoiceChatViewController.swift */; };
+		953FDA39244126AD00D04FA5 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953FDA38244126AD00D04FA5 /* StringExtension.swift */; };
 		F8361B4D7F56F83622B9DDE8 /* Pods_LexSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 177C26EFDC1486C509970AF0 /* Pods_LexSwift.framework */; };
 /* End PBXBuildFile section */
 
@@ -48,6 +49,7 @@
 		21D2D0F3B3AA17855995EE90 /* Pods-DeepSenseSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DeepSenseSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DeepSenseSwift/Pods-DeepSenseSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		6ACD689BA30992F1433ED163 /* Pods-DeepSenseSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DeepSenseSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-DeepSenseSwift/Pods-DeepSenseSwift.release.xcconfig"; sourceTree = "<group>"; };
 		74B47E3512F8472A89B6AFAE /* Pods-LexSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LexSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LexSwift/Pods-LexSwift.debug.xcconfig"; sourceTree = "<group>"; };
+		953FDA38244126AD00D04FA5 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		9EF2C706B11C9DA498BB3B1A /* Pods-LexSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LexSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-LexSwift/Pods-LexSwift.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -94,6 +96,7 @@
 				17DD068D1DD3EE9D00BD639D /* TableViewController.swift */,
 				17DD06911DD3F18100BD639D /* VoiceChatViewController.swift */,
 				17DA1C351DD517CD002DD9AF /* Constants.swift */,
+				953FDA38244126AD00D04FA5 /* StringExtension.swift */,
 			);
 			path = LexSwift;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 			files = (
 				17DA1C361DD517CD002DD9AF /* Constants.swift in Sources */,
 				17DD06921DD3F18100BD639D /* VoiceChatViewController.swift in Sources */,
+				953FDA39244126AD00D04FA5 /* StringExtension.swift in Sources */,
 				17DD067D1DD3C34A00BD639D /* ChatViewController.swift in Sources */,
 				17DD06671DD2C86200BD639D /* AppDelegate.swift in Sources */,
 				17DD068E1DD3EE9D00BD639D /* TableViewController.swift in Sources */,

--- a/Lex-Sample/Swift/LexSwift/ChatViewController.swift
+++ b/Lex-Sample/Swift/LexSwift/ChatViewController.swift
@@ -55,7 +55,6 @@ class ChatViewController: JSQMessagesViewController, JSQMessagesComposerTextView
     }
     
     override func didPressSend(_ button: UIButton, withMessageText text: String, senderId: String, senderDisplayName: String, date: Date) {
-     
         let message = JSQMessage(senderId: senderId, senderDisplayName: senderDisplayName, date: date, text: text)
         self.messages?.append(message!)
         
@@ -199,10 +198,13 @@ extension ChatViewController: AWSLexInteractionDelegate {
                 }
             } else {
                 //if you have special characters you need to be returned, make sure you base 64 encode your responses in your bot and then they will be decoded here as needed.
-                if let base64DecodedText = switchModeInput.outputText?.base64Decoded {
-                     message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: base64DecodedText)
+                guard let text = switchModeInput.outputText else {
+                    return //no response was returned
+                }
+                if let base64DecodedText = text.base64Decoded {
+                    message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: base64DecodedText)
                 } else {
-                    message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: switchModeInput.outputText!)
+                    message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: text)
                 }
                
                 print(switchModeInput.outputText!)

--- a/Lex-Sample/Swift/LexSwift/ChatViewController.swift
+++ b/Lex-Sample/Swift/LexSwift/ChatViewController.swift
@@ -207,7 +207,7 @@ extension ChatViewController: AWSLexInteractionDelegate {
                     message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: text)
                 }
                
-                print(switchModeInput.outputText!)
+                print(text)
 
                 self.messages?.append(message)
                 self.finishSendingMessage(animated: true)

--- a/Lex-Sample/Swift/LexSwift/ChatViewController.swift
+++ b/Lex-Sample/Swift/LexSwift/ChatViewController.swift
@@ -55,6 +55,7 @@ class ChatViewController: JSQMessagesViewController, JSQMessagesComposerTextView
     }
     
     override func didPressSend(_ button: UIButton, withMessageText text: String, senderId: String, senderDisplayName: String, date: Date) {
+     
         let message = JSQMessage(senderId: senderId, senderDisplayName: senderDisplayName, date: date, text: text)
         self.messages?.append(message!)
         
@@ -197,7 +198,15 @@ extension ChatViewController: AWSLexInteractionDelegate {
                     self.finishSendingMessage(animated: true)
                 }
             } else {
-                message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: switchModeInput.outputText!)
+                //if you have special characters you need to be returned, make sure you base 64 encode your responses in your bot and then they will be decoded here as needed.
+                if let base64DecodedText = switchModeInput.outputText?.base64Decoded {
+                     message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: base64DecodedText)
+                } else {
+                    message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: switchModeInput.outputText!)
+                }
+               
+                print(switchModeInput.outputText!)
+
                 self.messages?.append(message)
                 self.finishSendingMessage(animated: true)
             }

--- a/Lex-Sample/Swift/LexSwift/ChatViewController.swift
+++ b/Lex-Sample/Swift/LexSwift/ChatViewController.swift
@@ -206,8 +206,6 @@ extension ChatViewController: AWSLexInteractionDelegate {
                 } else {
                     message = JSQMessage(senderId: ServerSenderId, senderDisplayName: "", date: Date(), text: text)
                 }
-               
-                print(text)
 
                 self.messages?.append(message)
                 self.finishSendingMessage(animated: true)

--- a/Lex-Sample/Swift/LexSwift/StringExtension.swift
+++ b/Lex-Sample/Swift/LexSwift/StringExtension.swift
@@ -1,0 +1,29 @@
+//
+//  StringExtension.swift
+//  LexSwift
+//
+//  Created by Stone, Nicki on 4/10/20.
+//
+
+import Foundation
+
+public extension String {
+
+    /// Assuming the current string is base64 encoded, this property returns a String
+    /// initialized by converting the current string into Unicode characters, encoded to
+    /// utf8. If the current string is not base64 encoded, nil is returned instead.
+    var base64Decoded: String? {
+        guard let base64 = Data(base64Encoded: self) else { return nil }
+        let utf8 = String(data: base64, encoding: .utf8)
+        return utf8
+    }
+
+    /// Returns a base64 representation of the current string, or nil if the
+    /// operation fails.
+    var base64Encoded: String? {
+        let utf8 = self.data(using: .utf8)
+        let base64 = utf8?.base64EncodedString()
+        return base64
+    }
+
+}


### PR DESCRIPTION

*Description of changes:*  If a customer needs to include special characters in their response, they must base 64 encode the string before saving it in their bot. The sample app now base 64 decodes the response with this addition if the string comes back base 64 encoded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
