### PR TITLE
Bump SDK version for Lex Swift sample to 2.16.0

### DIFF
--- a/Lex-Sample/Swift/Podfile
+++ b/Lex-Sample/Swift/Podfile
@@ -3,9 +3,8 @@ use_frameworks!
 target :'LexSwift' do
   pod 'JSQMessagesViewController', '~>7.3.4'
 
-  $awsVersion = '~> 2.11.0'
+  $awsVersion = '~> 2.16.0'
   pod 'AWSMobileClient', $awsVersion
   pod 'AWSLex', $awsVersion
 end
-
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Lex/Swift sample isn't bumped from the bump version script, so this is a PR after

- [x] Investigate if this sample can built and run successfully with the latest version
- [x] merge an update to the bump version script here https://github.com/aws-amplify/aws-sdk-ios/pull/3000

Then merge this PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
